### PR TITLE
Ignore tenants

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If the comments are not provided the action will skip the diffing in this folder
 ## Inputs
 
 - **path-filter**: Comma separated string of paths that you want to do flux diff against. Supports glob patterns with wildcard characters (`*` and `**`). E.g. `/some/path/*` or `**/other-path/*` or `/some/path/*,**/other-path/*`. Defaults to `.`
-- **autodetect-ingore-tenants**: Flag to enable autodetection of tenants to ignore. Either "true" or "false". Useful when new tenants are applied to the repo, and you dont want the action to fail. It will look for new sync.yaml files in /tenant folder and assumes the sync.yaml contains a `apiVersion: kustomize.toolkit.fluxcd.io/v1 kind: Kustomization` object. The name of that object is used as tenant name.
+- **autodetect-ingore-tenants**: Flag to enable autodetection of tenants to ignore. Either "true" or "false". Useful when new tenants are applied to the repo, and you dont want the action to fail. It will look for new sync.yaml files in /tenant folder and assumes the sync.yaml contains a `kind: Kustomization` object. The name of that object is used as tenant name.
 - **additional-ignore-tenants**: Comma separated string of Flux tenants that you want to ignore. Useful if the tenant do not allready exist in the cluster and you do not want the action to fail.
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ If the comments are not provided the action will skip the diffing in this folder
 
 ## Inputs
 
-- **path-filter**: Comma separated paths that you want to do flux diff against. Supports glob patterns with wildcard characters (`*` and `**`). E.g. `/some/path/*` or `**/other-path/*` or `/some/path/*,**/other-path/*`. Defaults to `.`
+- **path-filter**: Comma separated string of paths that you want to do flux diff against. Supports glob patterns with wildcard characters (`*` and `**`). E.g. `/some/path/*` or `**/other-path/*` or `/some/path/*,**/other-path/*`. Defaults to `.`
+- **autodetect-ingore-tenants**: Flag to enable autodetection of tenants to ignore. Either "true" or "false". Useful when new tenants are applied to the repo, and you dont want the action to fail. It will look for new sync.yaml files in /tenant folder and assumes the sync.yaml contains a `apiVersion: kustomize.toolkit.fluxcd.io/v1 kind: Kustomization` object. The name of that object is used as tenant name.
+- **additional-ignore-tenants**: Comma separated string of Flux tenants that you want to ignore. Useful if the tenant do not allready exist in the cluster and you do not want the action to fail.
 
 ## Outputs
 
@@ -90,7 +92,7 @@ jobs:
         uses: azure/use-kubelogin@v1
         with:
           kubelogin-version: 'v0.0.24'
-      - name:
+      - name: Set AKS context
         uses: azure/aks-set-context@v4
         with:
           resource-group: '<azure-cluster-rg>'
@@ -100,6 +102,8 @@ jobs:
         uses: SparebankenVest/flux-diff-action@main
         with:
           path-filter: "some/path/*"
+          autodetect-ignore-tenants: "true"
+          additional-ignore-tenants: "some-tenant1,other-tenant"
         id: flux-diff
       - name: Show flux diff in PR
         if: github.event_name == 'pull_request'

--- a/action.yaml
+++ b/action.yaml
@@ -37,7 +37,7 @@ runs:
     - name: Run flux-diff.sh
       run: |
         PATH_FILTER=${{ inputs.path-filter }} \
-        AUTODETECT_IGNORE_TENANTS={{ inputs.autodetect-ignore-tenants }} \
+        AUTODETECT_IGNORE_TENANTS=${{ inputs.autodetect-ignore-tenants }} \
         IGNORE_TENANTS=${{ inputs.additional-ignore-tenants }} \
         ${{ github.action_path }}/flux-diff.sh
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -4,9 +4,17 @@ description: 'Run flux diff to see what changes would be applied to the cluster'
 author: 'SPV'
 inputs:
   path-filter:
-    description: "Path to filter the flux diff"
+    description: "Path to filter the flux diff. Comma separated string. E.g. 'some/path1,**/path2/*'"
     required: true
     default: "."
+  autodetect-ignore-tenants:
+    description: "Enable autodetect Flux tenants to ignore in the flux diff. It will look for new sync.yaml files in /tenant folder and assumes the sync.yaml contains a `apiVersion: kustomize.toolkit.fluxcd.io/v1 kind: Kustomization` object. The name of that object is used as tenant name."
+    required: false
+    default: "true"
+  additional-ingore-tenants:
+    description: "Flux tenants to ignore in the flux diff. Comma separated string. E.g. 'tenant1,tenant2'"
+    required: false
+    default: ""
 outputs:
   diff-output:
     description: "Flux diff output"
@@ -27,7 +35,11 @@ runs:
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
     - name: Run flux-diff.sh
-      run: PATH_FILTER=${{ inputs.path-filter }} ${{ github.action_path }}/flux-diff.sh
+      run: |
+        PATH_FILTER=${{ inputs.path-filter }} \
+        AUTODETECT_IGNORE_TENANTS={{ inputs.autodetect-ignore-tenants }} \
+        IGNORE_TENANTS=${{ inputs.additional-ignore-tenants }} \
+        ${{ github.action_path }}/flux-diff.sh
       shell: bash
     - name: Set diff output as action output
       shell: bash


### PR DESCRIPTION
add the following flags:
- `autodetect-ignore-tenants`: Wether or not to autodetect tenants to ignore. If new tenant is found (aka new sync.yaml) in /tenants. it will ignore this tenant. default to "true"
- `additional-ignore-tenants` : comma separated string with flux `Kustomization` names to ignore diffing against. Default to ""