### PR TITLE
Change functionality around secrets

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
-# CODEOWNERS: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+# CODEOWNERS: <https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax>
+
 *       @SparebankenVest/team-plattform

--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ If the comments are not provided the action will skip the diffing in this folder
 
 - **diff-output**: multiline string with diff output
 
+## Secret redaction
+
+The action redacts the **values** of every `data:` and `stringData:` block in the
+diff output before it is written to `diff-output`, the workflow logs, or a PR
+comment. Each value is replaced with `<redacted>`, while the keys and the fact
+that a resource changed remain visible.
+
+**Why this is done:** `flux diff kustomization` performs a server-side dry-run,
+which means it reads the live `Secret` objects from the cluster to compute the
+diff and can emit their decoded/base64 values into its output. Because this
+action surfaces that output in PR comments and Actions logs — both readable by
+anyone with access to the repository or the run — unredacted secret values would
+otherwise leak out of the cluster and into GitHub. Redacting the values keeps
+the review signal (a Secret was added/removed, or its keys changed) without
+exposing the secret material itself.
+
+**Scope and trade-offs:**
+- Redaction is **safe-by-default**: it masks *any* `data:`/`stringData:` block,
+  so `ConfigMap` values are redacted too. This is intentional — the diff stream
+  does not carry reliable `kind:` context per line, so distinguishing a Secret's
+  `data:` from a ConfigMap's `data:` cannot be done safely. We prefer over-
+  redacting non-sensitive ConfigMap values to ever risking a leaked secret.
+- This only redacts what appears in the **output**. `flux diff` still reads the
+  Secret from the cluster in memory to compute the diff, so the identity running
+  the action still needs read access to secrets in Kubernetes RBAC (`list`).
+
 ## Example (AZURE OIDC)
 
 Here is an example of how to use this action in a workflow and comment the output back in the PR.

--- a/flux-diff.sh
+++ b/flux-diff.sh
@@ -118,9 +118,58 @@ if [ -s tmp-changed-kustomization-dirs.txt ]; then
       else
         # Perform flux diff
         flux diff kustomization $TENANT --path $dir --progress-bar=false -n $NAMESPACE > tmp-flux-diff.txt
+        # Capture flux's exit code immediately; the redaction pipeline below would
+        # otherwise overwrite $? before the `case` statement inspects it.
+        FLUX_DIFF_RC=$?
+
+        # Redact Secret values from the diff output.
+        # `flux diff` reads live Secrets from the cluster to compute the diff and
+        # can emit their `data`/`stringData` contents into the output, which then
+        # ends up in workflow logs and PR comments. We keep the fact that a Secret
+        # changed (keys, add/remove) visible, but replace every value under a
+        # `data:` or `stringData:` block with a fixed placeholder so no secret
+        # material leaks. Diff line prefixes (space, +, -) are preserved.
+        #
+        # Behaviour: once inside a `data:`/`stringData:` block, every more-indented
+        # `key: value` line has its value replaced with `<redacted>`. The block
+        # ends when a line returns to the indentation of the `data:` key or less.
+        awk '
+          {
+            line = $0
+            # Strip a leading diff marker (space/+/-) for indentation analysis.
+            marker = ""
+            body = line
+            if (line ~ /^[ +-]/) { marker = substr(line, 1, 1); body = substr(line, 2) }
+
+            # Current indentation (leading spaces of the body).
+            match(body, /^ */); indent = RLENGTH
+
+            # Detect entering a data/stringData block.
+            if (body ~ /^ *(data|stringData): *$/) {
+              in_secret = 1
+              secret_indent = indent
+              print line
+              next
+            }
+
+            if (in_secret) {
+              # Leaving the block when indentation is back at/above the key level
+              # on a non-blank line.
+              if (body !~ /^ *$/ && indent <= secret_indent) {
+                in_secret = 0
+              } else if (body ~ /^ *[^ :][^:]*: */) {
+                # A "key: value" entry inside the block: redact the value.
+                sub(/: *.*$/, ": <redacted>", body)
+                print marker body
+                next
+              }
+            }
+            print line
+          }
+        ' tmp-flux-diff.txt > tmp-flux-diff-redacted.txt && mv tmp-flux-diff-redacted.txt tmp-flux-diff.txt
 
         # Check if flux diff was successful
-        case $? in
+        case $FLUX_DIFF_RC in
           0)
             printf -- '\n---\xE2\x9C\x93 No changes in %s---\n' $dir
             ;;


### PR DESCRIPTION
This pull request introduces a security improvement by ensuring that secret values are redacted from all `flux diff` outputs before they are surfaced in logs or PR comments. It also updates documentation to explain this behavior and makes a minor update to the `CODEOWNERS` file.

Secret redaction improvements:

* Added an `awk`-based redaction pipeline in `flux-diff.sh` to replace all values under `data:` and `stringData:` blocks in the diff output with `<redacted>`, preventing accidental leakage of secrets through logs or PR comments. This redacts both `Secret` and `ConfigMap` values for safety, as distinguishing between them in the diff output is not reliable.
* Updated the `README.md` with a new section describing the secret redaction behavior, its rationale, and its scope/trade-offs, so users understand what is being redacted and why.

Documentation and ownership:

* Updated the `CODEOWNERS` file to use a Markdown link format and clarified ownership for the repository.